### PR TITLE
Revert "Removed SNAPSHOT ending from artifacts"

### DIFF
--- a/bin/snapshots
+++ b/bin/snapshots
@@ -62,14 +62,14 @@ function stamped {
   local base=$($get_version)
   local today=$(date +"%Y-%m-%d")
   local sha=$(git log --pretty=format:'%h' -n 1)
-  echo "${base}-${today}-${sha}"
+  echo "${base}-${today}-${sha}-SNAPSHOT"
 }
 
 # versioned sbt build for play modules
 function build {
   local version=$1
   shift
-  sbt -Dplay.version=$PLAY_VERSION "set version in ThisBuild := \"$version\"" "set isSnapshot in ThisBuild := true" "$@"
+  sbt -Dplay.version=$PLAY_VERSION "set version in ThisBuild := \"$version\"" "$@"
 }
 
 # checkout branches and extract versions
@@ -113,7 +113,7 @@ echo
 
 cd $DEPLOY/playframework/framework
 git tag $PLAY_VERSION -a -m "Building $PLAY_VERSION"
-./build "set isSnapshot in ThisBuild := true" +publish
+./build +publish
 
 echo
 echo --- anorm $ANORM_VERSION


### PR DESCRIPTION
This reverts commit 05226ea28d87f4823e6b48a704bf9611c2e558a8.

Turns out we can't publish dependencies that don't end in SNAPSHOT to
sonatype snapshots repository.  So, we've switched to publishing sbt
plugin snapshots to sonatype snapshots repository instead of bintray.