### PR TITLE
Prepare for play-build-base for use in Play

### DIFF
--- a/bin/snapshots
+++ b/bin/snapshots
@@ -46,11 +46,6 @@ function checkout {
   git clean -fxd
 }
 
-# detect play base version
-function play_base_version {
-  echo $(cat version.sbt | sed 's/Release.branchVersion in ThisBuild := "\(.*\)-SNAPSHOT"/\1/')
-}
-
 # detect base version from version.sbt
 function base_version {
   echo $(cat version.sbt | sed 's/version in ThisBuild := "\(.*\)-SNAPSHOT"/\1/')
@@ -69,7 +64,7 @@ function stamped {
 function build {
   local version=$1
   shift
-  sbt -Dplay.version=$PLAY_VERSION "set version in ThisBuild := \"$version\"" "$@"
+  sbt -Dplay.version=$PLAY_VERSION -Dtwirl.version=$TWIRL_VERSION "set version in ThisBuild := \"$version\"" "$@"
 }
 
 # checkout branches and extract versions
@@ -79,7 +74,7 @@ echo "Checking out branches and extracting versions..."
 pushd $DEPLOY
 
 checkout $DEPLOY/playframework/framework $BRANCH
-PLAY_VERSION=$(stamped play_base_version)
+PLAY_VERSION=$(stamped base_version)
 
 checkout $DEPLOY/anorm $BRANCH
 ANORM_VERSION=$(stamped base_version)
@@ -108,12 +103,18 @@ echo "     omnidoc: $PLAY_VERSION"
 export PLAY_VERSION
 
 echo
+echo --- twirl $TWIRL_VERSION
+echo
+
+cd $DEPLOY/twirl
+build $TWIRL_VERSION ++2.11.1 publish ++2.10.4 publish plugin/publish
+
+echo
 echo --- play $PLAY_VERSION
 echo
 
 cd $DEPLOY/playframework/framework
-git tag $PLAY_VERSION -a -m "Building $PLAY_VERSION"
-./build +publish
+build $PLAY_VERSION +publish
 
 echo
 echo --- anorm $ANORM_VERSION
@@ -135,13 +136,6 @@ echo
 
 cd $DEPLOY/play-slick
 build $PLAY_SLICK_VERSION +publish
-
-echo
-echo --- twirl $TWIRL_VERSION
-echo
-
-cd $DEPLOY/twirl
-build $TWIRL_VERSION ++2.11.1 publish ++2.10.4 publish plugin/publish
 
 echo
 echo --- nightly status update

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.3.0"
 )
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.0")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.1")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "0.5.0")

--- a/src/main/scala/interplay/PlayBuildBase.scala
+++ b/src/main/scala/interplay/PlayBuildBase.scala
@@ -71,7 +71,8 @@ object PlayBuildBase extends AutoPlugin {
     homepage := Some(url(s"https://github.com/playframework/${(playBuildRepoName in ThisBuild).value}")),
     licenses := Seq("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.html")),
 
-    scalacOptions ++= Seq("-deprecation", "-feature", "-Xfatal-warnings", "-unchecked", "-encoding", "utf8"),
+    scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-encoding", "utf8"),
+    javacOptions ++= Seq("-encoding", "UTF-8", "-Xlint:-options"),
 
     releasePublishArtifactsAction := PgpKeys.publishSigned.value,
 
@@ -116,7 +117,6 @@ object PlaySbtPluginBase extends AutoPlugin {
 
   override def projectSettings = ScriptedPlugin.scriptedSettings ++ Seq(
     ScriptedPlugin.scriptedLaunchOpts <+= version apply { v => s"-Dproject.version=$v" },
-    ScriptedPlugin.scriptedLaunchOpts += "-XX:MaxPermSize=256m",
     sbtPlugin := true,
 
     publishTo := {
@@ -128,8 +128,8 @@ object PlaySbtPluginBase extends AutoPlugin {
     publishMavenStyle := isSnapshot.value,
     playBuildPromoteBintray in ThisBuild := true,
 
-    (javacOptions in compile) := Seq("-source", "1.7", "-target", "1.7"),
-    (javacOptions in doc) := Seq("-source", "1.7")
+    (javacOptions in compile) ++= Seq("-source", "1.6", "-target", "1.6"),
+    (javacOptions in doc) := Seq("-source", "1.6")
   )
 }
 
@@ -151,7 +151,7 @@ object PlayLibraryBase extends AutoPlugin {
     playBuildPromoteSonatype in ThisBuild := true,
     omnidocGithubRepo := s"playframework/${(playBuildRepoName in ThisBuild).value}",
     omnidocTagPrefix := "",
-    javacOptions in compile := Seq("-source", "1.8", "-target", "1.8"),
+    javacOptions in compile ++= Seq("-source", "1.8", "-target", "1.8"),
     javacOptions in doc := Seq("-source", "1.8"),
     crossScalaVersions := Seq("2.11.6", "2.10.5"),
     scalaVersion := sys.props.get("scala.version").getOrElse("2.10.5"),
@@ -173,8 +173,8 @@ object PlaySbtLibraryBase extends AutoPlugin {
 
   override def projectSettings = Seq(
     playBuildPromoteSonatype in ThisBuild := true,
-    (javacOptions in compile) := Seq("-source", "1.7", "-target", "1.7"),
-    (javacOptions in doc) := Seq("-source", "1.7")
+    (javacOptions in compile) := Seq("-source", "1.6", "-target", "1.6"),
+    (javacOptions in doc) := Seq("-source", "1.6")
   )
 }
 


### PR DESCRIPTION
* Update snapshots script so it doesn't pass version via tag to play
* Upgrade to latest sbt-release
* Turn off fatal warnings - no projects want it
* Lower target javac for sbt projects to 1.6