### PR TITLE
added scala 2.12.0-M5 cross version

### DIFF
--- a/src/main/scala/interplay/PlayBuildBase.scala
+++ b/src/main/scala/interplay/PlayBuildBase.scala
@@ -153,8 +153,8 @@ object PlayLibraryBase extends AutoPlugin {
     omnidocTagPrefix := "",
     javacOptions in compile ++= Seq("-source", "1.8", "-target", "1.8"),
     javacOptions in doc := Seq("-source", "1.8"),
-    crossScalaVersions := Seq(scalaVersion.value),
-    scalaVersion := sys.props.get("scala.version").getOrElse("2.11.7"),
+    crossScalaVersions := Seq(scalaVersion.value, "2.12.0-M5"),
+    scalaVersion := sys.props.get("scala.version").getOrElse("2.11.8"),
     playCrossBuildRootProject in ThisBuild := true
   )
 }
@@ -242,7 +242,7 @@ object PlayRootProjectBase extends AutoPlugin {
   override def projectSettings = PlayNoPublishBase.projectSettings ++ Seq(
     crossScalaVersions := {
       if ((playCrossBuildRootProject in ThisBuild).?.value.exists(identity)) {
-        Seq("2.11.7")
+        Seq("2.11.8", "2.12.0-M5")
       } else {
         crossScalaVersions.value
       }

--- a/src/sbt-test/interplay/library-with-plugin/test
+++ b/src/sbt-test/interplay/library-with-plugin/test
@@ -19,8 +19,10 @@ $ exists mock-sbt-plugin/target/scripted-ran
 
 # Make sure publishSigned ran on every project with the right publish settings
 > contains target/scala-2.11/publish-version no-publish:1.2.3
+> contains target/scala-2.12.0-M5/publish-version no-publish:1.2.3
 > contains mock-sbt-plugin/target/scala-2.10/sbt-0.13/publish-version Bintray-Sbt-Publish-playframework-sbt-plugin-releases-mock:1.2.3
 > contains mock-library/target/scala-2.11/publish-version sonatype-staging:1.2.3
+> contains mock-library/target/scala-2.12.0-M5/publish-version sonatype-staging:1.2.3
 > contains mock-sbt-library/target/scala-2.10/publish-version sonatype-staging:1.2.3
 
 # Make sure bintrayRelease ran only in the root project

--- a/src/sbt-test/interplay/library-with-root/test
+++ b/src/sbt-test/interplay/library-with-root/test
@@ -16,7 +16,9 @@ $ exec git branch -u origin/master
 
 # Make sure publishSigned ran on every project with the right publish settings
 > contains target/scala-2.11/publish-version no-publish:1.2.3
+> contains target/scala-2.12.0-M5/publish-version no-publish:1.2.3
 > contains mock-library/target/scala-2.11/publish-version sonatype-staging:1.2.3
+> contains mock-library/target/scala-2.12.0-M5/publish-version sonatype-staging:1.2.3
 
 # Make sure sonatypeRelease ran only in the root project
 > contains target/sonatype-release-version 1.2.3

--- a/src/sbt-test/interplay/library/test
+++ b/src/sbt-test/interplay/library/test
@@ -16,6 +16,7 @@ $ exec git branch -u origin/master
 
 # Make sure publishSigned ran
 > contains target/scala-2.11/publish-version sonatype-staging:1.2.3
+> contains target/scala-2.12.0-M5/publish-version sonatype-staging:1.2.3
 
 # Make sure sonatypeRelease ran
 > contains target/sonatype-release-version 1.2.3


### PR DESCRIPTION
Could be binary compatible with RC1 (as written in the news article) (See: http://www.scala-lang.org/news/2.12.0-M5/). 
And Scala 2.12 is feature complete since M4.

So I guess M5 is pretty good to try out Scala 2.12

Also Play-Doc and Twirl could be made working for 2.12 once https://github.com/etorreborre/specs2/issues/489 is fixed.