### PR TITLE
WIP: add sbt cross building options

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,11 +5,21 @@ lazy val interplay = (project in file("."))
 
 description := "Base build plugin for all Play modules"
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % sbtReleaseVersion)
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % sbtPgpVersion)
-addSbtPlugin("me.lessis" % "bintray-sbt" % bintraySbtVersion)
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % sbtSonatypeVersion)
-addSbtPlugin("com.lightbend" % "sbt-whitesource" % sbtWhitesourceVersion)
+val currentSbtVersion = sbtBinaryVersion in pluginCrossBuild
+
+// FIXME: https://github.com/sbt/sbt/issues/3393
+//addSbtPlugin("com.github.gseitz" %% "sbt-release" % sbtReleaseVersion)
+//addSbtPlugin("com.jsuereth" %% "sbt-pgp" % sbtPgpVersion)
+//addSbtPlugin("org.foundweekends" %% "sbt-bintray" % sbtBintrayVersion)
+//addSbtPlugin("org.xerial.sbt" %% "sbt-sonatype" % sbtSonatypeVersion)
+//addSbtPlugin("com.lightbend" %% "sbt-whitesource" % sbtWhitesourceVersion)
+libraryDependencies ++= Seq(
+  Defaults.sbtPluginExtra("com.github.gseitz" % "sbt-release" % sbtReleaseVersion, currentSbtVersion.value, scalaBinaryVersion.value),
+  Defaults.sbtPluginExtra("com.jsuereth" % "sbt-pgp" % sbtPgpVersion, currentSbtVersion.value, scalaBinaryVersion.value),
+  Defaults.sbtPluginExtra("org.foundweekends" % "sbt-bintray" % sbtBintrayVersion, currentSbtVersion.value, scalaBinaryVersion.value),
+  Defaults.sbtPluginExtra("org.xerial.sbt" % "sbt-sonatype" % sbtSonatypeVersion, currentSbtVersion.value, scalaBinaryVersion.value),
+  Defaults.sbtPluginExtra("com.lightbend" % "sbt-whitesource" % sbtWhitesourceVersion, currentSbtVersion.value, scalaBinaryVersion.value)
+)
 
 libraryDependencies ++= Seq(
   "org.scala-sbt" % "scripted-plugin" % scriptedPluginVersion,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.16

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,10 +5,10 @@ libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.3.1"
 )
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.1")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "0.5.0")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.6")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0-M1")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.1")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
 addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.5")
 
 lazy val build = (project in file(".")).

--- a/project/project/buildinfo.sbt
+++ b/project/project/buildinfo.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.4.0")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")


### PR DESCRIPTION
currently this allows for cross building sbt plugins for
all play plugins

still fails with:
```
[error] Modules were resolved with conflicting cross-version suffixes in {file:/Users/schmitch/projects/schmitch/play/interplay/}interplay:
[error]    org.json4s:json4s-ast _2.12, _2.10
[error]    org.json4s:json4s-core _2.12, _2.10
[error]    org.scala-sbt:io _2.12, <none>
java.lang.RuntimeException: Conflicting cross-version suffixes in: org.json4s:json4s-ast, 
/* STACKTRACE REMOVED */
[error] (*:update) Conflicting cross-version suffixes in: org.json4s:json4s-ast, org.json4s:json4s-core, org.scala-sbt:io
[error] Total time: 0 s, completed 03.08.2017 11:43:26
```