### PR TITLE
Support sbt 1.0.1 and 0.13.16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: scala
 dist: trusty
 sudo: false
 group: beta
-script: sbt test scripted
+script: sbt validate
 jdk:
 - oraclejdk8
 cache:

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ description := "Base build plugin for all Play modules"
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % sbtReleaseVersion)
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % sbtPgpVersion)
-addSbtPlugin("me.lessis" % "bintray-sbt" % bintraySbtVersion)
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % sbtBintrayVersion)
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % sbtSonatypeVersion)
 addSbtPlugin("com.lightbend" % "sbt-whitesource" % sbtWhitesourceVersion)
 
@@ -21,3 +21,11 @@ playBuildExtraTests := {
 }
 
 playBuildRepoName in ThisBuild := "interplay"
+
+sbtPlugin := true
+
+sbtVersion := "0.13.16"
+
+crossSbtVersions := Seq("0.13.16")
+
+addCommandAlias("validate", ";clean;test;scripted")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.16

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,10 +5,10 @@ libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.3.1"
 )
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.1")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "0.5.0")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.6")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.1")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.1")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
 addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.5")
 
 lazy val build = (project in file(".")).

--- a/project/project/buildinfo.sbt
+++ b/project/project/buildinfo.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.4.0")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")

--- a/src/sbt-test/interplay/library-with-plugin/.gitignore
+++ b/src/sbt-test/interplay/library-with-plugin/.gitignore
@@ -1,3 +1,4 @@
 target
+project/build.properties
 # global is created by scripted
 global

--- a/src/sbt-test/interplay/library-with-plugin/build.sbt
+++ b/src/sbt-test/interplay/library-with-plugin/build.sbt
@@ -63,5 +63,3 @@ commands in ThisBuild := {
     state
   } +: (commands in ThisBuild).value
 }
-
-

--- a/src/sbt-test/interplay/library-with-plugin/project/build.properties
+++ b/src/sbt-test/interplay/library-with-plugin/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=0.13.15

--- a/src/sbt-test/interplay/library-with-plugin/test
+++ b/src/sbt-test/interplay/library-with-plugin/test
@@ -7,13 +7,10 @@ $ exec git add .
 $ exec git commit -m commit
 
 # Setup remote git repo in target directory
-$ exec git init --bare target/remote
-$ exec git remote add origin target/remote
+$ exec git init --bare $PWD/target/remote
+$ exec git remote add origin $PWD/target/remote
 $ exec git push origin master
 $ exec git branch -u origin/master
-
-$ exec git status
-$ exec git diff
 
 > release with-defaults
 

--- a/src/sbt-test/interplay/library-with-plugin/test
+++ b/src/sbt-test/interplay/library-with-plugin/test
@@ -21,6 +21,7 @@ $ exists mock-sbt-plugin/target/scripted-ran
 > contains target/scala-2.11/publish-version no-publish:1.2.3
 > contains target/scala-2.12/publish-version no-publish:1.2.3
 > contains mock-sbt-plugin/target/scala-2.10/sbt-0.13/publish-version Bintray-Sbt-Publish-playframework-sbt-plugin-releases-mock:1.2.3
+> contains mock-sbt-plugin/target/scala-2.12/sbt-1.0/publish-version Bintray-Sbt-Publish-playframework-sbt-plugin-releases-mock:1.2.3
 > contains mock-library/target/scala-2.11/publish-version sonatype-staging:1.2.3
 > contains mock-library/target/scala-2.12/publish-version sonatype-staging:1.2.3
 > contains mock-sbt-library/target/scala-2.10/publish-version sonatype-staging:1.2.3

--- a/src/sbt-test/interplay/library-with-root/.gitignore
+++ b/src/sbt-test/interplay/library-with-root/.gitignore
@@ -1,3 +1,4 @@
 target
+project/build.properties
 # global is created by scripted
 global

--- a/src/sbt-test/interplay/library-with-root/project/build.properties
+++ b/src/sbt-test/interplay/library-with-root/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=0.13.15

--- a/src/sbt-test/interplay/library-with-root/test
+++ b/src/sbt-test/interplay/library-with-root/test
@@ -7,13 +7,10 @@ $ exec git add .
 $ exec git commit -m commit
 
 # Setup remote git repo in target directory
-$ exec git init --bare target/remote
-$ exec git remote add origin target/remote
+$ exec git init --bare $PWD/target/remote
+$ exec git remote add origin $PWD/target/remote
 $ exec git push origin master
 $ exec git branch -u origin/master
-
-$ exec git status
-$ exec git diff
 
 > release with-defaults
 

--- a/src/sbt-test/interplay/library/.gitignore
+++ b/src/sbt-test/interplay/library/.gitignore
@@ -1,3 +1,4 @@
 target
+project/build.properties
 # global is created by scripted
 global

--- a/src/sbt-test/interplay/library/project/build.properties
+++ b/src/sbt-test/interplay/library/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=0.13.15

--- a/src/sbt-test/interplay/library/test
+++ b/src/sbt-test/interplay/library/test
@@ -7,8 +7,8 @@ $ exec git add .
 $ exec git commit -m commit
 
 # Setup remote git repo in target directory
-$ exec git init --bare target/remote
-$ exec git remote add origin target/remote
+$ exec git init --bare $PWD/target/remote
+$ exec git remote add origin $PWD/target/remote
 $ exec git push origin master
 $ exec git branch -u origin/master
 

--- a/src/sbt-test/interplay/plugin-with-root/.gitignore
+++ b/src/sbt-test/interplay/plugin-with-root/.gitignore
@@ -1,3 +1,4 @@
 target
+project/build.properties
 # global is created by scripted
 global

--- a/src/sbt-test/interplay/plugin-with-root/project/build.properties
+++ b/src/sbt-test/interplay/plugin-with-root/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=0.13.15

--- a/src/sbt-test/interplay/plugin-with-root/test
+++ b/src/sbt-test/interplay/plugin-with-root/test
@@ -7,13 +7,10 @@ $ exec git add .
 $ exec git commit -m commit
 
 # Setup remote git repo in target directory
-$ exec git init --bare target/remote
-$ exec git remote add origin target/remote
+$ exec git init --bare $PWD/target/remote
+$ exec git remote add origin $PWD/target/remote
 $ exec git push origin master
 $ exec git branch -u origin/master
-
-$ exec git status
-$ exec git diff
 
 > release with-defaults
 

--- a/src/sbt-test/interplay/plugin/.gitignore
+++ b/src/sbt-test/interplay/plugin/.gitignore
@@ -1,3 +1,4 @@
 target
+project/build.properties
 # global is created by scripted
 global

--- a/src/sbt-test/interplay/plugin/project/build.properties
+++ b/src/sbt-test/interplay/plugin/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=0.13.15

--- a/src/sbt-test/interplay/plugin/test
+++ b/src/sbt-test/interplay/plugin/test
@@ -12,7 +12,7 @@ $ exec git remote add origin $PWD/target/remote
 $ exec git push origin master
 $ exec git branch -u origin/master
 
-> release with-defaults
+> release cross with-defaults
 
 # Make sure scripted tests ran
 $ exists target/scripted-ran

--- a/src/sbt-test/interplay/plugin/test
+++ b/src/sbt-test/interplay/plugin/test
@@ -7,13 +7,10 @@ $ exec git add .
 $ exec git commit -m commit
 
 # Setup remote git repo in target directory
-$ exec git init --bare target/remote
-$ exec git remote add origin target/remote
+$ exec git init --bare $PWD/target/remote
+$ exec git remote add origin $PWD/target/remote
 $ exec git push origin master
 $ exec git branch -u origin/master
-
-$ exec git status
-$ exec git diff
 
 > release with-defaults
 

--- a/src/sbt-test/interplay/plugin/test
+++ b/src/sbt-test/interplay/plugin/test
@@ -19,6 +19,7 @@ $ exists target/scripted-ran
 
 # Make sure publishSigned ran
 > contains target/scala-2.10/sbt-0.13/publish-version Bintray-Sbt-Publish-playframework-sbt-plugin-releases-mock:1.2.3
+> contains target/scala-2.12/sbt-1.0/publish-version Bintray-Sbt-Publish-playframework-sbt-plugin-releases-mock:1.2.3
 
 # Make sure bintrayRelease ran
 > contains target/bintray-release-version 1.2.3


### PR DESCRIPTION
This replaces #32 to support 1.0.1 and 0.13.16.

I'm creating a new PR to keep the work done for #32 as a work-in-progress to migrate interplay from sbt 0.13 to 1.0.

This is based on the feedback from @jroper here: https://github.com/playframework/interplay/pull/32#issuecomment-322335403

Basically, we aren't cross building interplay, but instead just providing the right configuration for plugins that will be cross build (like twirl and play itself).