### PR TITLE
New snapshot script for stable branch

### DIFF
--- a/bin/snapshots
+++ b/bin/snapshots
@@ -35,38 +35,9 @@ if [ -z "$DEPLOY" ] ; then
   DEPLOY=$(pwd)
 fi
 
-# checkout out a clean version of a branch
-function checkout {
-  local dir=$1
-  local branch=$2
-  echo "Checking out $dir ($branch)"
-  cd $dir
-  git fetch
-  git checkout $branch
-  git reset --hard origin/$branch
-  git clean -fxd
-}
-
-# detect base version from version.sbt
-function base_version {
-  echo $(cat version.sbt | sed 's/version in ThisBuild := "\(.*\)-SNAPSHOT"/\1/')
-}
-
-# create a timestamped and git hashed version
-function stamped {
-  local get_version=$1
-  local base=$($get_version)
-  local today=$(date +"%Y-%m-%d")
-  local sha=$(git log --pretty=format:'%h' -n 1)
-  echo "${base}-${today}-${sha}-SNAPSHOT"
-}
-
-# versioned sbt build for play modules
-function build {
-  local version=$1
-  shift
-  sbt -Dplay.version=$PLAY_VERSION "set version in ThisBuild := \"$version\"" "$@"
-}
+DIR="${BASH_SOURCE%/*}"
+if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
+source "$DIR/utils"
 
 # checkout branches and extract versions
 

--- a/bin/stableSnapshots
+++ b/bin/stableSnapshots
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+# Deploy script for nightly snapshots of the stable Play branch.
+#
+# Note: this only applies to the core Play projects in the playframework repo.
+#
+# Expects to be run against a directory with checked out repositories for:
+#
+#   - playframework
+#   - omnidoc
+#   - play-generated-docs
+
+set -e
+
+# process arguments
+
+unset DEPLOY
+declare BRANCH=2.6.x # change this to latest stable branch
+declare -a args
+
+while [[ $# -gt 0 ]] ; do
+  case "$1" in
+    -b|--branch) branch=$2; shift 2 ;;
+    *) args=("${args[@]}" "$1"); shift ;;
+  esac
+done
+set -- "${args[@]}"
+
+DEPLOY=$1
+
+if [ -z "$DEPLOY" ] ; then
+  DEPLOY=$(pwd)
+fi
+
+DIR="${BASH_SOURCE%/*}"
+if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
+source "$DIR/utils"
+
+# checkout branches and extract versions
+
+echo "Checking out branches and extracting versions..."
+
+pushd $DEPLOY
+
+checkout $DEPLOY/playframework/framework $BRANCH
+PLAY_VERSION=$(stamped base_version)
+
+# build and publish snapshots
+
+echo
+echo --- Building snapshots for Play $PLAY_VERSION
+echo
+
+export PLAY_VERSION
+
+echo
+echo --- play $PLAY_VERSION
+echo
+
+cd $DEPLOY/playframework/framework
+build $PLAY_VERSION +publish
+
+echo
+echo --- omnidoc $PLAY_VERSION
+echo
+
+versions=""
+versions="$versions -Dplay.version=$PLAY_VERSION"
+
+checkout $DEPLOY/omnidoc $BRANCH
+sbt $versions +publish
+
+echo
+echo --- play-generated-docs
+echo
+
+$DEPLOY/omnidoc/bin/deploy --branch $BRANCH $DEPLOY/play-generated-docs
+
+
+# cleanup
+
+popd
+unset PLAY_VERSION

--- a/bin/utils
+++ b/bin/utils
@@ -1,0 +1,34 @@
+# Utilities for snapshot scripts
+
+# checkout out a clean version of a branch
+function checkout {
+  local dir=$1
+  local branch=$2
+  echo "Checking out $dir ($branch)"
+  cd $dir
+  git fetch
+  git checkout $branch
+  git reset --hard origin/$branch
+  git clean -fxd
+}
+
+# detect base version from version.sbt
+function base_version {
+  echo $(cat version.sbt | sed 's/version in ThisBuild := "\(.*\)-SNAPSHOT"/\1/')
+}
+
+# create a timestamped and git hashed version
+function stamped {
+  local get_version=$1
+  local base=$($get_version)
+  local today=$(date +"%Y-%m-%d")
+  local sha=$(git log --pretty=format:'%h' -n 1)
+  echo "${base}-${today}-${sha}-SNAPSHOT"
+}
+
+# versioned sbt build for play modules
+function build {
+  local version=$1
+  shift
+  sbt -Dplay.version=$PLAY_VERSION "set version in ThisBuild := \"$version\"" "$@"
+}


### PR DESCRIPTION
The current snapshot script is completely broken for stable branches, since the branch names don't match up between repositories.

For the stable branches (currently 2.6.x) I created a separate script that only releases the main playframework repo and omnidoc. This means for the external projects like play-json, play-ws, play-slick, etc., we won't publish and depend on those snapshots. Those repositories are easy enough to release so I don't think that's a major concern.

Note that since we release omnidoc, if we need to update the doc for say, play-json on 2.6.x, it should be sufficient to release a new play-json version and update the omnidoc configuration to include that version. Then the doc should be updated on the next nightly release.

I tested the release with [this version](https://oss.sonatype.org/content/repositories/snapshots/com/typesafe/play/sbt-plugin_2.10_0.13/2.6.6-2017-09-21-9974d8306-SNAPSHOT/) and it works when I switch out the version on the starter example.