### PR TITLE
Use + to run commands cross build

### DIFF
--- a/src/main/scala/interplay/PlayBuildBase.scala
+++ b/src/main/scala/interplay/PlayBuildBase.scala
@@ -252,14 +252,14 @@ object PlayReleaseBase extends AutoPlugin {
         commitReleaseVersion,
         tagRelease,
 
-        if (sbtPlugin.value) ReleaseStep(action = Command.process("publishSigned", _), enableCrossBuild = true)
+        if (sbtPlugin.value) releaseStepCommandAndRemaining("+publishSigned")
         else publishArtifacts,
 
         releaseStepTask(playBuildExtraPublish in thisProjectRef.value),
         ifDefinedAndTrue(playBuildPromoteBintray, releaseStepTask(bintrayRelease in thisProjectRef.value)),
 
         if (sbtPlugin.value)
-          ifDefinedAndTrue(playBuildPromoteSonatype, ReleaseStep(action = Command.process("sonatypeRelease", _), enableCrossBuild = true))
+          ifDefinedAndTrue(playBuildPromoteSonatype, releaseStepCommandAndRemaining("+sonatypeRelease"))
         else
           ifDefinedAndTrue(playBuildPromoteSonatype, releaseStepCommand("sonatypeRelease")),
 


### PR DESCRIPTION
This is more friendly when using sbt-doge and sbt-release. It is also more readable.