### PR TITLE
Correct the default release process

### DIFF
--- a/src/main/scala/interplay/PlayBuildBase.scala
+++ b/src/main/scala/interplay/PlayBuildBase.scala
@@ -248,23 +248,21 @@ object PlayReleaseBase extends AutoPlugin {
         checkSnapshotDependencies,
         inquireVersions,
         runClean,
-        runTest,
+
+        if (playCrossReleasePlugins.value) releaseStepCommandAndRemaining("+test")
+        else runTest,
+
         releaseStepTask(playBuildExtraTests in thisProjectRef.value),
         setReleaseVersion,
         commitReleaseVersion,
         tagRelease,
 
-        if (sbtPlugin.value && playCrossReleasePlugins.value) releaseStepCommandAndRemaining("+publishSigned")
+        if (playCrossReleasePlugins.value) releaseStepCommandAndRemaining("+publishSigned")
         else publishArtifacts,
 
         releaseStepTask(playBuildExtraPublish in thisProjectRef.value),
         ifDefinedAndTrue(playBuildPromoteBintray, releaseStepTask(bintrayRelease in thisProjectRef.value)),
-
-        if (sbtPlugin.value && playCrossReleasePlugins.value)
-          ifDefinedAndTrue(playBuildPromoteSonatype, releaseStepCommandAndRemaining("+sonatypeRelease"))
-        else
-          ifDefinedAndTrue(playBuildPromoteSonatype, releaseStepCommand("sonatypeRelease")),
-
+        ifDefinedAndTrue(playBuildPromoteSonatype, releaseStepCommand("sonatypeRelease")),
         setNextVersion,
         commitNextVersion,
         pushChanges


### PR DESCRIPTION
The release process is defined only for the root project and not for each sub-project. So, if the
root project is not an sbt plugin (which is the most common case), then it will not run cross build for
the subprojects.

Also, the sonatypeRelease does not need to cross run since it creates only a staged repository.