### PR TITLE
Cross-build interplay for sbt 0.13 and sbt 1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,6 @@ import buildinfo.BuildInfo._
 
 lazy val interplay = (project in file("."))
   .enablePlugins(PlaySbtPlugin && PlayReleaseBase)
-  .settings(playCrossReleasePlugins := false)
 
 description := "Base build plugin for all Play modules"
 
@@ -12,21 +11,42 @@ addSbtPlugin("org.foundweekends" % "sbt-bintray" % sbtBintrayVersion)
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % sbtSonatypeVersion)
 addSbtPlugin("com.lightbend" % "sbt-whitesource" % sbtWhitesourceVersion)
 
-libraryDependencies ++= Seq(
-  "org.scala-sbt" % "scripted-plugin" % scriptedPluginVersion,
-  "com.typesafe" % "config" % configVersion
-)
+libraryDependencies += "com.typesafe" % "config" % configVersion
+
+// The location of the scripted-plugin changed from sbt 1
+// onwards. The following conditional allows interplay to
+// be built as both an sbt 0.13 and sbt 1 plugin.
+libraryDependencies += {
+  val sbtVer = (sbtVersion in pluginCrossBuild).value
+  CrossVersion.partialVersion(sbtVer) match {
+    case Some((0, _)) =>
+      // sbt 0.x plugins weren't cross-built
+      "org.scala-sbt" % "scripted-plugin" % sbtVer
+    case Some((major, _)) if major >= 1 =>
+      // sbt 1+ plugins are cross-built
+      "org.scala-sbt" %% "scripted-plugin" % sbtVer
+    case unknown =>
+      sys.error(s"Can't work out scripted plugin for sbt version: $sbtVer (partial version: $unknown)")
+  }
+}
 
 playBuildExtraTests := {
   scripted.toTask("").value
+}
+
+// Supply the sbt.version to the scripted tests so
+// that they can be run with either sbt 0.13 or
+// sbt 1.
+scriptedLaunchOpts += {
+  val sbtV = (sbtVersion in pluginCrossBuild).value
+  s"-Dsbt.version=$sbtV"
 }
 
 playBuildRepoName in ThisBuild := "interplay"
 
 sbtPlugin := true
 
-sbtVersion := "0.13.16"
-
-crossSbtVersions := Seq("0.13.16")
-
-addCommandAlias("validate", ";clean;test;scripted")
+// Used by CI to check that interplay is working. Note
+// that the scripted tests are cross-built; i.e. they are
+// run for both sbt 0.13 and sbt 1.
+addCommandAlias("validate", ";clean;+test;+scripted")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.0.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,14 +1,14 @@
 import java.util.Locale
 
 libraryDependencies ++= Seq(
-  "org.scala-sbt" % "scripted-plugin" % sbtVersion.value,
+  "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value,
   "com.typesafe" % "config" % "1.3.1"
 )
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.6")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.1")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.1")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
 addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.10")
 
 lazy val build = (project in file(".")).
@@ -20,4 +20,27 @@ lazy val build = (project in file(".")).
     }
   )
 
-unmanagedSourceDirectories in Compile += baseDirectory.value.getParentFile / "src" / "main" / "scala"
+// The interplay "meta-build"—the stuff inside the `project`
+// directory—uses interplay as a plugin. Since we haven't run the
+// interplay "proper build"—the stuff in the root directory—yet we
+// can't just say "addSbtPlugin(..."interplay"...) we need to actually
+// compile the plugin sources as part of the meta-build.
+//
+// We do this by adding some of the interplay source directories to
+// the meta-build. This means that interplay will be compiled once as
+// part of the meta-build (but not published) and then *again* as part
+// of the proper build (where it is properly cross-compiled and
+// published).
+//
+// Note that for the meta-build we only need to include the files in
+// `scala-sbt-1.0` directory, not the files in the `scala-sbt-0.13`
+// directory. This is because the meta-build in the `project`
+// directory is only built with sbt 1 (the value set in the
+// build.properties file). In a later stage of the sbt build, when we
+// do the "proper build" in the root directory, interplay will be
+// cross-compiled for both sbt 1 and sbt 0.13. At this stage, for the
+// meta-build, we only need sbt 1.
+unmanagedSourceDirectories in Compile ++= Seq(
+  baseDirectory.value.getParentFile / "src" / "main" / "scala",
+  baseDirectory.value.getParentFile / "src" / "main" / "scala-sbt-1.0"
+)

--- a/src/main/scala-sbt-0.13/interplay/PlaySbtCompat.scala
+++ b/src/main/scala-sbt-0.13/interplay/PlaySbtCompat.scala
@@ -1,0 +1,130 @@
+package interplay
+
+import java.io.File
+
+import sbt._
+import sbt.compiler.{AnalyzingCompiler, Eval, JavaTool}
+
+/**
+ * An object that offers compatibility helpers when creating builds that must work in
+ * different versions of sbt. This version is designed to be compatible with sbt 0.13.
+ */
+object PlaySbtCompat {
+  /**
+   * If the ScriptedPlugin is an AutoPlugin then provide it here. This is
+   * convenient if we want to disable it automatically. The plugin is a
+   * normal plugin in sbt 0.13 and an AutoPlugin (which we often need to
+   * disable) in sbt 1.0.
+   *
+   * @see https://github.com/sbt/sbt/issues/3514
+   */
+  def optScriptedAutoPlugin: Option[AutoPlugin] = None
+  /** Access to the ScriptedPlugin's settings. */
+  def scriptedSettings: Seq[Setting[_]] = ScriptedPlugin.scriptedSettings
+  /** The ScriptedPlugin's `scriptedLaunchOpts` setting. */
+  def scriptedLaunchOpts: SettingKey[Seq[String]] = ScriptedPlugin.scriptedLaunchOpts
+  /** The ScriptedPlugin's `scripted` task. */
+  def scriptedTask: InputKey[Unit] = ScriptedPlugin.scripted
+
+  /** Various methods that have changed signature or location between sbt 0.13 and 1.0 */
+  object PathCompat {
+    def allPaths(base: File): PathFinder = base.***
+    def relativeTo(f: File): PathMap = IO.relativize(f, _)
+    def relativeTo(bases: Iterable[File]): PathMap = Path.relativeTo(bases)
+    def rebase(a: File, b: String): PathMap = Path.rebase(a, b)
+  }
+
+  /** The Process object used by this version of sbt. */
+  val Process = sbt.Process
+
+  /**
+   * Provides access to sbt Load functionality. The method signature changed
+   * in sbt 1 and the class moved to an internal package.
+   */
+  object LoadCompat {
+    def defaultLoad(state: State, localBase: java.io.File): (() => Eval, BuildStructure) = {
+      Load.defaultLoad(state, localBase, state.log)
+    }
+    def getRootProject(map: Map[URI, sbt.BuildUnitBase]): URI => String = {
+      Load.getRootProject(map)
+    }
+    def reapply(
+        newSettings: Seq[Setting[_]],
+        structure: BuildStructure
+    )(implicit display: Show[ScopedKey[_]]): BuildStructure = {
+      Load.reapply(newSettings, structure)
+    }
+  }
+
+  /**
+   * Provides access to sbt EvaluateConfigurations functionality. The method signature changed
+   * in sbt 1 and the class moved to an internal package.
+   */
+  object EvaluateConfigurationsCompat {
+    def evaluateConfigurations(sbtFile: java.io.File, imports: Seq[String], classLoader: ClassLoader, eval: () => Eval): Seq[Def.Setting[_]] = {
+      EvaluateConfigurations.evaluateConfiguration(eval(), sbtFile, imports)(classLoader)
+    }
+  }
+
+  /**
+   * Run the scaladoc task, but with optional caching.
+   *
+   * Caching can be disabled to work around: https://github.com/sbt/sbt/issues/1614
+   */
+  def scaladocTask(
+      label: String, cacheName: Option[String],
+      sources: Seq[File], classpath: Seq[File],
+      outputDirectory: File, options: Seq[String]): Def.Initialize[Task[Unit]] = Def.task {
+
+    // This is based on code in sbt.Defaults and sbt.Doc
+    val scalac: AnalyzingCompiler = Keys.compilers.value.scalac
+    val docGen: RawCompileLike.Gen = scalac.doc
+    docTask(
+      label + " Scala API documentation", cacheName, docGen,
+      sources, sourceFilter = (_: File) => true,
+      classpath, outputDirectory, options)
+  }
+
+  /**
+   * Run the javadoc task, but with optional caching.
+   *
+   * Caching can be disabled to work around: https://github.com/sbt/sbt/issues/1614
+   */
+  def javadocTask(
+      label: String, cacheName: Option[String],
+      sources: Seq[File], classpath: Seq[File],
+      outputDirectory: File, options: Seq[String]): Def.Initialize[Task[Unit]] = Def.task {
+
+    // This is based on code in sbt.Defaults and sbt.Doc
+    val javac: JavaTool = Keys.compilers.value.javac
+    val docGen: RawCompileLike.Gen = javac.doc
+    docTask(
+      label + " Java API documentation", cacheName, docGen,
+      sources, sourceFilter = Doc.javaSourcesOnly,
+      classpath, outputDirectory, options)
+  }
+
+   /** Used to run scaladoc or javadoc with caching, etc. Takes a Gen, wraps it and calls it. */
+   private def docTask(
+      prepareMsg: String, cacheName: Option[String], compileGen: RawCompileLike.Gen,
+      sources: Seq[File], sourceFilter: File => Boolean, classpath: Seq[File],
+      outputDirectory: File, options: Seq[String]): Def.Initialize[Task[Unit]] = Def.task {
+
+    // This is based on code in sbt.Defaults and sbt.Doc. We wrap take a function of
+    // type RawCompileLike.Gen then wrap it to add more functionality (e.g. filtering,
+    // caching).
+    val streamsValue = Keys.streams.value
+    val prepareGen: RawCompileLike.Gen = RawCompileLike.prepare(prepareMsg, compileGen)
+    val filterGen: RawCompileLike.Gen = RawCompileLike.filterSources(sourceFilter, prepareGen)
+    val maybeCacheGen: RawCompileLike.Gen = cacheName match {
+      case None => filterGen // Not cached
+      case Some(dirName) =>
+        RawCompileLike.cached(
+          new File(streamsValue.cacheDirectory, dirName),
+          filterGen
+        )
+    }
+    maybeCacheGen(sources, classpath, outputDirectory, options, 10, streamsValue.log)
+  }
+
+}

--- a/src/main/scala-sbt-1.0/interplay/NopCacheStore.scala
+++ b/src/main/scala-sbt-1.0/interplay/NopCacheStore.scala
@@ -1,0 +1,29 @@
+ package interplay
+
+ import sbt.util.{CacheStore, CacheStoreFactory}
+ import sjsonnew.support.scalajson.unsafe.Converter
+ import sjsonnew.{JsonReader, JsonWriter}
+
+/**
+ * Creates a cache which does nothing. Used by PlaySbtCompat. Helpful for
+ * working around https://github.com/sbt/sbt/issues/1614
+ */
+object NopCacheStoreFactory extends CacheStoreFactory {
+  override def make(identifier: String): CacheStore = NopCacheStore
+  /**
+   * The sub-factory operation just returns the same object
+   * since there's no difference between nop-factories.
+   */
+  override def sub(identifier: String): CacheStoreFactory = this
+}
+
+/**
+ * A cache which does nothing. Used by PlaySbtCompat. Helpful for
+ * working around https://github.com/sbt/sbt/issues/1614
+ */
+object NopCacheStore extends CacheStore {
+  override def read[T: JsonReader]() = Converter.fromJsonOptionUnsafe(None)
+  override def write[T: JsonWriter](value: T) = Converter.toJson(value)
+  override def delete() = ()
+  override def close() = ()
+}

--- a/src/main/scala-sbt-1.0/interplay/PlaySbtCompat.scala
+++ b/src/main/scala-sbt-1.0/interplay/PlaySbtCompat.scala
@@ -1,0 +1,133 @@
+package interplay
+
+import java.io.File
+
+import sbt.Keys._
+import sbt.inc.{Doc => IncDoc}
+import sbt.internal.inc.{AnalyzingCompiler, ManagedLoggedReporter}
+import sbt.io.Path._
+import sbt.io.{IO, PathFinder}
+import sbt.util.CacheStoreFactory
+import sbt.{Def, _}
+import xsbti.Reporter
+import xsbti.compile.{Compilers, IncToolOptionsUtil}
+
+/**
+ * An object that offers compatibility helpers when creating builds that must work in
+ * different versions of sbt. This version is designed to be compatible with sbt 1.0.
+ */
+object PlaySbtCompat {
+  /**
+   * If the ScriptedPlugin is an AutoPlugin then provide it here. This is
+   * convenient if we want to disable it automatically. The plugin is a
+   * normal plugin in sbt 0.13 and an AutoPlugin (which we often need to
+   * disable) in sbt 1.0.
+   *
+   * @see https://github.com/sbt/sbt/issues/3514
+   */
+  def optScriptedAutoPlugin: Option[AutoPlugin] = Some(ScriptedPlugin)
+  /** Access to the ScriptedPlugin's settings. */
+  def scriptedSettings: Seq[Setting[_]] = ScriptedPlugin.projectSettings
+  /** The ScriptedPlugin's `scriptedLaunchOpts` setting. */
+  def scriptedLaunchOpts: SettingKey[Seq[String]] = ScriptedPlugin.autoImport.scriptedLaunchOpts
+  /** The ScriptedPlugin's `scripted` task. */
+  def scriptedTask: InputKey[Unit] = ScriptedPlugin.autoImport.scripted
+
+  /** Various methods that have changed signature or location between sbt 0.13 and 1.0 */
+  object PathCompat {
+    def allPaths(f: File): PathFinder = f.allPaths
+    def relativeTo(f: File): PathMap = IO.relativize(f, _)
+    def relativeTo(bases: Iterable[File]): PathMap = Path.relativeTo(bases)
+    def rebase(a: File, b: String): PathMap = Path.rebase(a, b)
+  }
+
+  /** The Process object used by this version of sbt. */
+  val Process = scala.sys.process.Process
+
+  /**
+   * Provides access to sbt's Load functionality. The method signature changed
+   * in sbt 1 and the class moved to an internal package.
+   */
+  val LoadCompat = sbt.internal.PlayLoad
+
+  /**
+   * Provides access to sbt's EvaluateConfigurations functionality. The method signature changed
+   * in sbt 1 and the class moved to an internal package.
+   */
+  val EvaluateConfigurationsCompat = sbt.internal.PlayEvaluateConfigurations
+
+  /**
+   * Run the scaladoc task, but with optional caching.
+   *
+   * Caching can be disabled to work around: https://github.com/sbt/sbt/issues/1614
+   */
+  def scaladocTask(
+    label: String, cacheName: Option[String],
+    sources: Seq[File], classpath: Seq[File], outputDirectory: File, options: Seq[String]) = Def.task {
+    // This code based on sbt.Defaults
+    val cs: Compilers = Keys.compilers.value
+    val s: TaskStreams = streams.value
+    val scalac: AnalyzingCompiler = cs.scalac.asInstanceOf[AnalyzingCompiler]
+    val cacheStoreFactory: CacheStoreFactory = optionalCache(cacheName).value
+    val runDoc: RawCompileLike.Gen =
+      Doc.scaladoc(label, cacheStoreFactory, scalac)
+    runDoc(sources, classpath, outputDirectory, options, maxErrors.value, s.log)
+   }
+
+  /**
+   * Run the javadoc task, but with optional caching.
+   *
+   * Caching can be disabled to work around: https://github.com/sbt/sbt/issues/1614
+   */
+  def javadocTask(
+      label: String, cacheName: Option[String],
+      sources: Seq[File], classpath: Seq[File], outputDirectory: File, options: Seq[String]) = Def.task {
+    // This code based on sbt.Defaults.docTaskSettings
+    val cs: Compilers = Keys.compilers.value
+    val s: TaskStreams = streams.value
+    val scalac: AnalyzingCompiler = cs.javaTools.asInstanceOf[AnalyzingCompiler]
+    val cacheStoreFactory: CacheStoreFactory = optionalCache(cacheName).value
+
+    val javadoc: IncDoc.JavaDoc = IncDoc.cachedJavadoc(label, cacheStoreFactory, cs.javaTools)
+
+    // We can't access `(compilerReporter in compile).value` so we recreate it
+    // here.
+    val defaultCompilerReporter: Reporter = {
+      // Copy of a private method from sbt.Defaults
+      def foldMappers[A](mappers: Seq[A => Option[A]]) = {
+        mappers.foldRight({ p: A =>
+          p
+        }) { (mapper, mappers) => { p: A =>
+          mapper(p).getOrElse(mappers(p))
+        }
+        }
+      }
+      new ManagedLoggedReporter(
+        maxErrors.value,
+        s.log,
+        foldMappers(sourcePositionMappers.value)
+      )
+    }
+
+    // This code based on sbt.Defaults.docTaskSettings
+    javadoc.run(sources.toList,
+      classpath.toList,
+      outputDirectory,
+      options.toList,
+      IncToolOptionsUtil.defaultIncToolOptions(),
+      s.log,
+      defaultCompilerReporter
+    )
+  }
+
+  /**
+   * Gets a cache if a name is provided, otherwise use a nop cache.
+   */
+  private def optionalCache(cacheName: Option[String]): Def.Initialize[Task[CacheStoreFactory]] = Def.task {
+    cacheName match {
+      case None => NopCacheStoreFactory // Not cached
+      case Some(dirName) => streams.value.cacheStoreFactory.sub(dirName)
+    }
+  }
+
+}

--- a/src/main/scala-sbt-1.0/sbt/internal/PlayEvaluateConfigurations.scala
+++ b/src/main/scala-sbt-1.0/sbt/internal/PlayEvaluateConfigurations.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package sbt.internal
+
+import sbt._
+import sbt.internal._
+import sbt.compiler.Eval
+
+/**
+ * Provides access to an interal sbt class. Accessed through the PlaySbtCompat object.
+ */
+object PlayEvaluateConfigurations {
+
+  def evaluateConfigurations(sbtFile: java.io.File, imports: Seq[String], classLoader: ClassLoader, eval: () => Eval): Seq[Def.Setting[_]] = {
+    EvaluateConfigurations.evaluateConfiguration(eval(), sbtFile, imports)(classLoader)
+  }
+
+}

--- a/src/main/scala-sbt-1.0/sbt/internal/PlayLoad.scala
+++ b/src/main/scala-sbt-1.0/sbt/internal/PlayLoad.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package sbt.internal
+
+import sbt._
+import sbt.compiler.Eval
+import sbt.util.Show
+
+/**
+ * Provides access to an interal sbt class. Accessed through the PlaySbtCompat object.
+ */
+object PlayLoad {
+
+  def defaultLoad(state: State, localBase: java.io.File): (() => Eval, BuildStructure) = {
+    Load.defaultLoad(state, localBase, state.log)
+  }
+
+  def getRootProject(map: Map[URI, BuildUnitBase]): URI => String = {
+    Load.getRootProject(map)
+  }
+
+  def reapply(
+      newSettings: Seq[Setting[_]],
+      structure: BuildStructure
+  )(implicit display: Show[ScopedKey[_]]): BuildStructure = {
+    Load.reapply(newSettings, structure)
+  }
+
+}

--- a/src/main/scala/interplay/Playdoc.scala
+++ b/src/main/scala/interplay/Playdoc.scala
@@ -6,6 +6,7 @@ import sbt.Keys._
 object Playdoc extends AutoPlugin {
 
   object autoImport {
+    final val Docs = config("docs")
     val playdocDirectory = settingKey[File]("Base directory of play documentation")
     val playdocPackage = taskKey[File]("Package play documentation")
   }
@@ -21,11 +22,11 @@ object Playdoc extends AutoPlugin {
     Seq(
       playdocDirectory := (baseDirectory in ThisBuild).value / "docs" / "manual",
       mappings in playdocPackage := {
-        val base = playdocDirectory.value
-        base.***.get pair relativeTo(base.getParentFile)
+        val base: File = playdocDirectory.value
+        PlaySbtCompat.PathCompat.allPaths(base).pair(PlaySbtCompat.PathCompat.relativeTo(base.getParentFile))
       },
       artifactClassifier in playdocPackage := Some("playdoc"),
-      artifact in playdocPackage ~= { _.copy(configurations = Seq(Docs)) }
+      artifact in playdocPackage ~= { _.withConfigurations(Vector(Docs)) }
     ) ++
     addArtifact(artifact in playdocPackage, playdocPackage)
 

--- a/src/sbt-test/interplay/library-with-plugin/build.sbt
+++ b/src/sbt-test/interplay/library-with-plugin/build.sbt
@@ -47,12 +47,50 @@ playBuildExtraPublish := {
 playBuildRepoName in ThisBuild := "mock"
 
 // Below this line is for facilitating tests
+
 InputKey[Unit]("contains") := {
   val args = Def.spaceDelimited().parsed
-  val contents = IO.read(file(args.head))
+  val filename = substVersions(sbtVersion.value, args.head)
   val expected = args.tail.mkString(" ")
-  if (!contents.contains(expected)) {
-    throw sys.error(s"File ${args.head} does not contain '$expected':\n$contents")
+  val contents: String = IO.read(file(filename))
+  if (contents.contains(expected)) {
+    println(s"Checked that $filename contains $expected")
+  } else {
+    throw sys.error(s"File $filename does not contain '$expected':\n$contents")
+  }
+}
+
+InputKey[Unit]("existsCustom") := {
+  val args = Def.spaceDelimited().parsed
+  val filename = substVersions(sbtVersion.value, args.head)
+  assert(args.tail.isEmpty)
+  val exists: Boolean = file(filename).exists()
+  if (exists) {
+    println(s"Checked that $filename exists")
+  } else {
+    throw sys.error(s"File $filename does not exist")
+  }
+}
+
+def substVersions(sbtVersion: String, str: String): String = {
+  val substitutions: Seq[(String, String)] = if (sbtVersion.startsWith("0.13.")) {
+    // Note: run 'OTHER_' substitutions first otherwise they won't work
+    Vector(
+      "OTHER_SBT_API" -> "1.0",
+      "OTHER_SCALA_API" -> "2.12",
+      "SBT_API" -> "0.13",
+      "SCALA_API" -> "2.10"
+    )
+  } else {
+    Vector(
+      "OTHER_SBT_API" -> "0.13",
+      "OTHER_SCALA_API" -> "2.10",
+      "SBT_API" -> "1.0",
+      "SCALA_API" -> "2.12"
+    )
+  }
+  substitutions.foldLeft(str) {
+    case (currStr, (target, replacement)) => currStr.replace(target, replacement)
   }
 }
 

--- a/src/sbt-test/interplay/library-with-plugin/test
+++ b/src/sbt-test/interplay/library-with-plugin/test
@@ -24,7 +24,7 @@ $ exists mock-sbt-plugin/target/scripted-ran
 > contains mock-sbt-plugin/target/scala-2.12/sbt-1.0/publish-version Bintray-Sbt-Publish-playframework-sbt-plugin-releases-mock:1.2.3
 > contains mock-library/target/scala-2.11/publish-version sonatype-staging:1.2.3
 > contains mock-library/target/scala-2.12/publish-version sonatype-staging:1.2.3
-> contains mock-sbt-library/target/scala-2.10/publish-version sonatype-staging:1.2.3
+> contains mock-sbt-library/target/scala-SCALA_API/publish-version sonatype-staging:1.2.3
 
 # Make sure bintrayRelease ran only in the root project
 > contains target/bintray-release-version 1.2.3

--- a/src/sbt-test/interplay/plugin-with-root/test
+++ b/src/sbt-test/interplay/plugin-with-root/test
@@ -18,8 +18,9 @@ $ exec git branch -u origin/master
 $ exists mock-sbt-plugin/target/scripted-ran
 
 # Make sure publishSigned ran on every project with the right publish settings
-> contains target/scala-2.10/publish-version no-publish:1.2.3
+> contains target/scala-SCALA_API/publish-version no-publish:1.2.3
 -$ exists target/scala-2.11/publish-version
+> existsCustom target/scala-OTHER_SCALA_API/publish-version
 > contains mock-sbt-plugin/target/scala-2.10/sbt-0.13/publish-version Bintray-Sbt-Publish-playframework-sbt-plugin-releases-mock:1.2.3
 > contains mock-sbt-plugin/target/scala-2.12/sbt-1.0/publish-version Bintray-Sbt-Publish-playframework-sbt-plugin-releases-mock:1.2.3
 

--- a/src/sbt-test/interplay/plugin-without-cross-release/build.sbt
+++ b/src/sbt-test/interplay/plugin-without-cross-release/build.sbt
@@ -1,3 +1,4 @@
+
 // What an actual project would look like
 lazy val `mock-sbt-plugin` = (project in file("."))
   .enablePlugins(PlaySbtPlugin && PlayReleaseBase)
@@ -16,12 +17,50 @@ playBuildRepoName in ThisBuild := "mock-without-cross-release"
 playCrossReleasePlugins := false
 
 // Below this line is for facilitating tests
+
 InputKey[Unit]("contains") := {
   val args = Def.spaceDelimited().parsed
-  val contents = IO.read(file(args.head))
+  val filename = substVersions(sbtVersion.value, args.head)
   val expected = args.tail.mkString(" ")
-  if (!contents.contains(expected)) {
-    throw sys.error(s"File ${args.head} does not contain '$expected':\n$contents")
+  val contents: String = IO.read(file(filename))
+  if (contents.contains(expected)) {
+    println(s"Checked that $filename contains $expected")
+  } else {
+    throw sys.error(s"File $filename does not contain '$expected':\n$contents")
+  }
+}
+
+InputKey[Unit]("existsCustom") := {
+  val args = Def.spaceDelimited().parsed
+  val filename = substVersions(sbtVersion.value, args.head)
+  assert(args.tail.isEmpty)
+  val exists: Boolean = file(filename).exists()
+  if (exists) {
+    println(s"Checked that $filename exists")
+  } else {
+    throw sys.error(s"File $filename does not exist")
+  }
+}
+
+def substVersions(sbtVersion: String, str: String): String = {
+  val substitutions: Seq[(String, String)] = if (sbtVersion.startsWith("0.13.")) {
+    // Note: run 'OTHER_' substitutions first otherwise they won't work
+    Vector(
+      "OTHER_SBT_API" -> "1.0",
+      "OTHER_SCALA_API" -> "2.12",
+      "SBT_API" -> "0.13",
+      "SCALA_API" -> "2.10"
+    )
+  } else {
+    Vector(
+      "OTHER_SBT_API" -> "0.13",
+      "OTHER_SCALA_API" -> "2.10",
+      "SBT_API" -> "1.0",
+      "SCALA_API" -> "2.12"
+    )
+  }
+  substitutions.foldLeft(str) {
+    case (currStr, (target, replacement)) => currStr.replace(target, replacement)
   }
 }
 

--- a/src/sbt-test/interplay/plugin-without-cross-release/test
+++ b/src/sbt-test/interplay/plugin-without-cross-release/test
@@ -18,10 +18,10 @@ $ exec git branch -u origin/master
 $ exists target/scripted-ran
 
 # Make sure publishSigned ran
-> contains target/scala-2.10/sbt-0.13/publish-version Bintray-Sbt-Publish-playframework-sbt-plugin-releases-mock-without-cross-release:1.2.3
+> contains target/scala-SCALA_API/sbt-SBT_API/publish-version Bintray-Sbt-Publish-playframework-sbt-plugin-releases-mock-without-cross-release:1.2.3
 
 # Make sure it does not run cross release
--$ exists target/scala-2.12/sbt-1.0/publish-version
+-> existsCustom target/scala-OTHER_SCALA_API/sbt-OTHER_SBT_API/publish-version
 
 # Make sure bintrayRelease ran
 > contains target/bintray-release-version 1.2.3

--- a/src/sbt-test/interplay/plugin/build.sbt
+++ b/src/sbt-test/interplay/plugin/build.sbt
@@ -1,3 +1,5 @@
+import interplay.PlaySbtCompat
+
 // What an actual project would look like
 lazy val `mock-sbt-plugin` = (project in file("."))
   .enablePlugins(PlaySbtPlugin && PlayReleaseBase)
@@ -24,6 +26,7 @@ InputKey[Unit]("contains") := {
 }
 
 def common: Seq[Setting[_]] = Seq(
+  PlaySbtCompat.scriptedTask := PlaySbtCompat.scriptedTask.evaluated,
   PgpKeys.publishSigned := {
     IO.write(crossTarget.value / "publish-version", s"${publishTo.value.get.name}:${version.value}")
   },


### PR DESCRIPTION
This is a work in progress - **do not merge**.

Change interplay build to use sbt 1 and interplay plugin to work with either sbt 0.13 or sbt 1.

* Loads properly with play-json, playframework and twirl in both sbt 0.13 and sbt 1.0.
* Cross-building has an issue where it tries to build plugins with Scala 2.11. This seemed to happen with the previous build of interplay too, but it obviously wasn't a problem. I don't understand the issues here or mechanism for propagating Scala version into subprojects.
* The scripted tests for interplay worked at one point but are currently failing. 😢 
* This should be easy to rebase - it's just a matter of merging build.property file(s).