### PR TITLE
Update Whitesource project naming policy

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,7 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % sbtPgpVersion)
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % sbtBintrayVersion)
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % sbtSonatypeVersion)
 addSbtPlugin("com.lightbend" % "sbt-whitesource" % sbtWhitesourceVersion)
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % sbtGitVersion)
 
 libraryDependencies ++= Seq(
   "org.scala-sbt" % "scripted-plugin" % scriptedPluginVersion,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,7 +9,8 @@ addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.6")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.1")
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.1")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
-addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.5")
+addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.7")
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")
 
 lazy val build = (project in file(".")).
   enablePlugins(BuildInfoPlugin).

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,7 +9,7 @@ addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.6")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.1")
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.1")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
-addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.7")
+addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.10")
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")
 
 lazy val build = (project in file(".")).

--- a/src/main/scala/interplay/PlayBuildBase.scala
+++ b/src/main/scala/interplay/PlayBuildBase.scala
@@ -290,17 +290,17 @@ object PlayWhitesourcePlugin extends AutoPlugin {
           "master"
         } else {
           // If it is not "master", then it is a release branch
-          // that should also be handled as an adhoc report.
+          // that should also be handled as an snapshot report.
           CrossVersion.partialVersion((version in LocalRootProject).value) match {
-            case Some((major, minor)) => s"$major.$minor-adhoc"
-            case None => "adhoc"
+            case Some((major, minor)) => s"$major.$minor-snapshot"
+            case None => "snapshot"
           }
         }
       } else {
         // Here we have only the case where we are releasing a version.
         CrossVersion.partialVersion((version in LocalRootProject).value) match {
           case Some((major, minor)) => s"$major.$minor-stable"
-          case None => "adhoc"
+          case None => "snapshot"
         }
       }
     }

--- a/src/main/scala/interplay/PlayBuildBase.scala
+++ b/src/main/scala/interplay/PlayBuildBase.scala
@@ -281,7 +281,7 @@ object PlayWhitesourcePlugin extends AutoPlugin {
 
   override lazy val projectSettings = Seq(
     whitesourceProduct := "Lightbend Reactive Platform",
-    whitesourceAggregateProjectName := {
+    whitesourceAggregateProjectName := (moduleName in LocalRootProject).value + "-" + {
       if (isSnapshot.value) {
         // There are two scenarios then:
         // 1. It is the master branch


### PR DESCRIPTION
So we would have:

1. play-framework-master: reports for master branch
2. play-framework-2.6-snapshot: reports for 2.6.x branch
3. play-framework-2.6-stable: reports for 2.6.x releases

This change won't affect Play 2.5.x since it is using an older version of interplay.