### PR TITLE
Avoid sbt-git since it can't handle worktrees

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,6 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % sbtPgpVersion)
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % sbtBintrayVersion)
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % sbtSonatypeVersion)
 addSbtPlugin("com.lightbend" % "sbt-whitesource" % sbtWhitesourceVersion)
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % sbtGitVersion)
 
 libraryDependencies ++= Seq(
   "org.scala-sbt" % "scripted-plugin" % scriptedPluginVersion,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,7 +10,6 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.1")
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.1")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
 addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.10")
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")
 
 lazy val build = (project in file(".")).
   enablePlugins(BuildInfoPlugin).

--- a/src/main/scala/interplay/PlayBuildBase.scala
+++ b/src/main/scala/interplay/PlayBuildBase.scala
@@ -2,7 +2,6 @@ package interplay
 
 import bintray.BintrayPlugin
 import bintray.BintrayPlugin.autoImport._
-import com.typesafe.sbt.SbtGit.GitKeys._
 import com.typesafe.sbt.SbtPgp
 import com.typesafe.sbt.pgp.PgpKeys
 import interplay.Omnidoc.autoImport._
@@ -286,7 +285,8 @@ object PlayWhitesourcePlugin extends AutoPlugin {
         // There are two scenarios then:
         // 1. It is the master branch
         // 2. It is a release branch (2.6.x, 2.5.x, etc)
-        if (gitCurrentBranch.value == "master") {
+        val branch = getCurrentGitBranch()
+        if (branch == "master") {
           "master"
         } else {
           // If it is not "master", then it is a release branch
@@ -305,6 +305,10 @@ object PlayWhitesourcePlugin extends AutoPlugin {
       }
     }
   )
+
+  // Run git command rather than using sbt-git/JGit, because JGit has a bug
+  // that prevents it from working with git worktrees: https://github.com/sbt/sbt/issues/2323
+  private def getCurrentGitBranch(): String = sbt.Process("git symbolic-ref --short HEAD").!!.trim
 }
 
 /**


### PR DESCRIPTION
Run git command rather than using sbt-git/JGit, because JGit has a bug that prevents it from working with git worktrees.

See: https://github.com/sbt/sbt/issues/2323