### PR TITLE
publish snapshots for 2.7.x branch

### DIFF
--- a/bin/snapshots
+++ b/bin/snapshots
@@ -83,7 +83,7 @@ echo --- twirl $TWIRL_VERSION
 echo
 
 cd $DEPLOY/twirl
-build $TWIRL_VERSION ++2.11.11 ++2.12.2 publish ++2.10.6 publish plugin/publish
+build $TWIRL_VERSION +publish
 
 echo
 echo --- play $PLAY_VERSION
@@ -111,7 +111,7 @@ echo --- play-ebean $PLAY_EBEAN_VERSION
 echo
 
 cd $DEPLOY/play-ebean
-build $PLAY_EBEAN_VERSION +publish plugin/publish
+build $PLAY_EBEAN_VERSION +publish
 
 echo
 echo --- play-slick $PLAY_SLICK_VERSION

--- a/bin/snapshots
+++ b/bin/snapshots
@@ -23,7 +23,7 @@ declare -a args
 
 while [[ $# -gt 0 ]] ; do
   case "$1" in
-    -b|--branch) branch=$2; shift 2 ;;
+    -b|--branch) BRANCH=$2; shift 2 ;;
     *) args=("${args[@]}" "$1"); shift ;;
   esac
 done

--- a/bin/stableSnapshots
+++ b/bin/stableSnapshots
@@ -15,12 +15,12 @@ set -e
 # process arguments
 
 unset DEPLOY
-declare BRANCH=2.6.x # change this to latest stable branch
+declare BRANCH=2.7.x # change this to latest stable branch
 declare -a args
 
 while [[ $# -gt 0 ]] ; do
   case "$1" in
-    -b|--branch) branch=$2; shift 2 ;;
+    -b|--branch) BRANCH=$2; shift 2 ;;
     *) args=("${args[@]}" "$1"); shift ;;
   esac
 done


### PR DESCRIPTION
This set interplay to default to 2.7.x and make it possible to override it as well. 

Resolves https://github.com/playframework/playframework/issues/8946