### PR TITLE
Remove anorm from published snapshots

### DIFF
--- a/bin/snapshots
+++ b/bin/snapshots
@@ -6,7 +6,6 @@
 #
 #   - playframework
 #   - scalatestplus-play
-#   - anorm
 #   - play-ebean
 #   - play-slick
 #   - twirl
@@ -50,9 +49,6 @@ PLAY_VERSION=$(stamped base_version)
 
 checkout $DEPLOY/scalatestplus-play $BRANCH
 SCALATESTPLUS_PLAY_VERSION=$(stamped base_version)
-
-checkout $DEPLOY/anorm $BRANCH
-ANORM_VERSION=$(stamped base_version)
 
 checkout $DEPLOY/play-ebean $BRANCH
 PLAY_EBEAN_VERSION=$(stamped base_version)
@@ -100,13 +96,6 @@ cd $DEPLOY/scalatestplus-play
 build $SCALATESTPLUS_PLAY_VERSION +publish
 
 echo
-echo --- anorm $ANORM_VERSION
-echo
-
-cd $DEPLOY/anorm
-build $ANORM_VERSION +publish
-
-echo
 echo --- play-ebean $PLAY_EBEAN_VERSION
 echo
 
@@ -134,7 +123,6 @@ cat - > ~/.interplay/$BRANCH/status.json <<STATUSJSON
   "versions": {
     "play": "$PLAY_VERSION",
     "scalatestplus-play": "$SCALATESTPLUS_PLAY_VERSION",
-    "anorm": "$ANORM_VERSION",
     "play-ebean": "$PLAY_EBEAN_VERSION",
     "play-slick": "$PLAY_SLICK_VERSION",
     "twirl": "$TWIRL_VERSION"
@@ -149,7 +137,6 @@ echo
 versions=""
 versions="$versions -Dplay.version=$PLAY_VERSION"
 versions="$versions -Dscalatestplus-play.version=$SCALATESTPLUS_PLAY_VERSION"
-versions="$versions -Danorm.version=$ANORM_VERSION"
 versions="$versions -Dplay-ebean.version=$PLAY_EBEAN_VERSION"
 versions="$versions -Dplay-slick.version=$PLAY_SLICK_VERSION"
 versions="$versions -Dtwirl.version=$TWIRL_VERSION"


### PR DESCRIPTION
Anorm now has its own publishing cycle independent from Play.