### PR TITLE
Use sbt-dynver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ install: jabba install "adopt@~1.$TRAVIS_JDK.0-0" && jabba use "$_" && java -Xmx
 
 script: sbt validate
 
+git:
+  depth: false # Avoid sbt-dynver not seeing the tag
+
 cache:
   directories:
   - "$HOME/.ivy2/cache"

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,40 @@
 import _root_.interplay.ScalaVersions._
 import buildinfo.BuildInfo._
 
+// Customise sbt-dynver's behaviour to make it work with tags which aren't v-prefixed
+dynverVTagPrefix in ThisBuild := false
+
+// Sanity-check: assert that version comes from a tag (e.g. not a too-shallow clone)
+// https://github.com/dwijnand/sbt-dynver/#sanity-checking-the-version
+Global / onLoad := (Global / onLoad).value.andThen { s =>
+  val v = version.value
+  if (dynverGitDescribeOutput.value.hasNoTags)
+    throw new MessageOnlyException(
+      s"Failed to derive version from git tags. Maybe run `git fetch --unshallow`? Version: $v"
+    )
+  s
+}
+
+
 lazy val interplay = (project in file("."))
   .enablePlugins(PlaySbtPlugin && PlayReleaseBase, SbtPlugin)
+  .settings(
+    Seq(
+      // Release settings
+      releaseProcess := {
+        import ReleaseTransformations._
+        Seq[ReleaseStep](
+          checkSnapshotDependencies,
+          runClean,
+          releaseStepCommandAndRemaining("+test"),
+          releaseStepTask(playBuildExtraTests in thisProjectRef.value),
+          releaseStepCommandAndRemaining("+publishSigned"),
+          releaseStepTask(bintrayRelease in thisProjectRef.value),
+          pushChanges
+        )
+      }
+    )
+  )
 
 description := "Base build plugin for all Play modules"
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,6 +10,7 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.5")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.8.1")
 addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.18")
+addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.0.0")
 
 lazy val build = (project in file(".")).
   enablePlugins(BuildInfoPlugin).

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,0 @@
-version in ThisBuild := "2.1.5-SNAPSHOT"


### PR DESCRIPTION
After making all those changes and seeing that interplay is now overriding its own definition, I think we should have interplay 3.0.0, with a release process adapted for sbt-dynver. 

I don't think it will help us to decommission `interplay`, there are a lot of useful things here.