### PR TITLE
Docs Omnidoc AutoPlugin

### DIFF
--- a/src/main/scala/interplay/Omnidoc.scala
+++ b/src/main/scala/interplay/Omnidoc.scala
@@ -4,6 +4,11 @@ import sbt._
 import sbt.Keys._
 import sbt.Package.ManifestAttributes
 
+
+/** 
+  * This AutoPlugin adds the `Omnidoc-Source-URL` key on the MANIFEST.MF of artifact-sources.jar so 
+  * later Omnidoc can use that value to link scaladocs to GitHub sources. 
+  */
 object Omnidoc extends AutoPlugin {
 
   object autoImport {


### PR DESCRIPTION
IMHO, the `Omnidoc` Autoplugin should be renamed to `SourcesUrlMetedata`.