### PR TITLE
JPMS Automatic-Module-Name for all jars published

### DIFF
--- a/src/main/scala/interplay/AutomaticModuleName.scala
+++ b/src/main/scala/interplay/AutomaticModuleName.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ */
+package interplay
+
+import sbt.Def
+import sbt._
+import sbt.Keys._
+
+/**
+ * Helper to set Automatic-Module-Name in projects.
+ *
+ * !! DO NOT BE TEMPTED INTO AUTOMATICALLY DERIVING THE NAMES FROM PROJECT NAMES !!
+ *
+ * The names carry a lot of implications and DO NOT have to always align 1:1 with the group ids or package names,
+ * though there should be of course a strong relationship between them.
+ */
+object AutomaticModuleName {
+  private val AutomaticModuleName = "Automatic-Module-Name"
+
+  def settings(name: String): Seq[Def.Setting[Task[Seq[PackageOption]]]] = Seq(
+    packageOptions in (Compile, packageBin) += Package.ManifestAttributes(AutomaticModuleName -> name)
+  )
+}


### PR DESCRIPTION
Required AutomaticModuleName.scala to be moved into interplay by both Pull Request comments https://github.com/playframework/playframework/pull/10087#issuecomment-596103514 and https://github.com/playframework/play-ws/pull/474#discussion_r387251231

I'm using the below commands;
```
interplay $ sbt clean publishLocal
[info] Loading settings for project interplay-build-build from buildinfo.sbt ...
[info] Loading project definition from /PROJECT_HOME/project/project
[info] Loading settings for project build from plugins.sbt ...
[info] Loading project definition from /PROJECT_HOME/project
[info] Loading settings for project interplay from build.sbt ...
[info] Set current project to interplay (in build file:/PROJECT_HOME/)
[success] Total time: 0 s, completed 09-Mar-2020 08:08:24
[info] Wrote /PROJECT_HOME/target/scala-2.12/sbt-1.0/interplay-3.0.0+14-cd168093.pom
[info] Main Scala API documentation to /PROJECT_HOME/target/scala-2.12/sbt-1.0/api...
[info] Compiling 17 Scala sources to /PROJECT_HOME/target/scala-2.12/sbt-1.0/classes ...
model contains 25 documentable templates
[info] Main Scala API documentation successful.
[info] :: delivering :: com.typesafe.play#interplay;3.0.0+14-cd168093 :: 3.0.0+14-cd168093 :: integration :: Mon Mar 09 08:08:37 GMT 2020
[info] 	delivering ivy file to /PROJECT_HOME/target/scala-2.12/sbt-1.0/ivy-3.0.0+14-cd168093.xml
[info] 	published interplay to /USER_HOME/.ivy2/local/com.typesafe.play/interplay/scala_2.12/sbt_1.0/3.0.0+14-cd168093/poms/interplay.pom
[info] 	published interplay to /USER_HOME/.ivy2/local/com.typesafe.play/interplay/scala_2.12/sbt_1.0/3.0.0+14-cd168093/jars/interplay.jar
[info] 	published interplay to /USER_HOME/.ivy2/local/com.typesafe.play/interplay/scala_2.12/sbt_1.0/3.0.0+14-cd168093/srcs/interplay-sources.jar
[info] 	published interplay to /USER_HOME/.ivy2/local/com.typesafe.play/interplay/scala_2.12/sbt_1.0/3.0.0+14-cd168093/docs/interplay-javadoc.jar
[info] 	published ivy to /USER_HOME/.ivy2/local/com.typesafe.play/interplay/scala_2.12/sbt_1.0/3.0.0+14-cd168093/ivys/ivy.xml
[success] Total time: 13 s, completed 09-Mar-2020 08:08:37
interplay $ 
```

then;
- `playframework $ sbt clean package -Dinterplay.version=3.0.0+14-cd168093`
- `sbt clean package -Dinterplay.version=3.0.0+14-cd168093`

Which i believe are correct, but they fail with;
```
/PLAYFRAMEWORK_HOME/build.sbt:9: error: object AutomaticModuleName is not a member of package interplay
import interplay.AutomaticModuleName
       ^
/PLAYFRAMEWORK_HOME/build.sbt:63: error: not found: value AutomaticModuleName
  .settings(AutomaticModuleName.settings("play.exceptions"))
...
```