### PR TITLE
Upgrade versions

### DIFF
--- a/src/main/scala/interplay/Versions.scala
+++ b/src/main/scala/interplay/Versions.scala
@@ -1,11 +1,11 @@
 package interplay
 
 object ScalaVersions {
-  val scala212 = "2.12.11"
-  val scala213 = "2.13.2"
+  val scala212 = "2.12.13"
+  val scala213 = "2.13.5"
 }
 
 object SbtVersions {
   val sbt10 = "1.2.8"
-  val sbt13 = "1.3.10"
+  val sbt13 = "1.3.13"
 }


### PR DESCRIPTION
Scala [2.12.13](https://github.com/scala/scala/releases/tag/v2.12.13) allows us to use `@nowarn` and `-Wconf`