### PR TITLE
[2.1.x] Upgrade versions

### DIFF
--- a/src/main/scala/interplay/PlayBuildBase.scala
+++ b/src/main/scala/interplay/PlayBuildBase.scala
@@ -17,8 +17,8 @@ import sbtwhitesource.WhiteSourcePlugin.autoImport._
 
 object ScalaVersions {
   val scala210 = "2.10.7"
-  val scala212 = "2.12.11"
-  val scala213 = "2.13.2"
+  val scala212 = "2.12.13"
+  val scala213 = "2.13.5"
 }
 
 object SbtVersions {


### PR DESCRIPTION
Scala [2.12.13](https://github.com/scala/scala/releases/tag/v2.12.13) allows us to use `@nowarn` and `-Wconf`