### PR TITLE
Rename master branch to main

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,7 +3,7 @@ name: Release Drafter
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   update_release_draft:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -33,14 +33,14 @@ pull_request_rules:
       label:
         remove: [status:needs-backport-1.3]
 
-  - name: forward patches to master branch
+  - name: forward patches to main branch
     conditions:
       - merged
       - label=status:needs-forwardport
     actions:
       backport:
         branches:
-          - master
+          - main
       label:
         remove: [status:needs-forwardport]
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ stages:
   - name: check
 
   - name: publish
-    if: ((branch = master AND type = push) OR (tag IS present)) AND NOT fork
+    if: ((branch = main AND type = push) OR (tag IS present)) AND NOT fork
 
 cache:
   directories:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Interplay is a set of sbt plugins for Play builds, sharing common configuration between Play builds so that they can be configured in one place.
 
-[![Build Status](https://travis-ci.org/playframework/interplay.svg?branch=master)](https://travis-ci.org/playframework/interplay)
+[![Build Status](https://travis-ci.org/playframework/interplay.svg?branch=main)](https://travis-ci.org/playframework/interplay)
 
 ## Usage
 

--- a/src/main/scala/interplay/Omnidoc.scala
+++ b/src/main/scala/interplay/Omnidoc.scala
@@ -29,7 +29,7 @@ object Omnidoc extends AutoPlugin {
 
   override def projectSettings = Seq(
     omnidocSourceUrl := omnidocGithubRepo.?.value map { repo =>
-      val development: String = (omnidocSnapshotBranch ?? "master").value
+      val development: String = (omnidocSnapshotBranch ?? "main").value
       val tagged: String = (omnidocTagPrefix ?? "v").value + version.value
       val tree: String = if (isSnapshot.value) development else tagged
       val prefix: String = "/" + (omnidocPathPrefix ?? "").value

--- a/src/main/scala/interplay/PlayBuildBase.scala
+++ b/src/main/scala/interplay/PlayBuildBase.scala
@@ -22,7 +22,7 @@ object PlayBuildBase extends AutoPlugin {
 
     // This is not using sbt-git because we need a more stable way to set
     // the current branch in a more stable way, for example, we may want to
-    // get the current branch as "master" even if we are at a detached commit.
+    // get the current branch as "main" even if we are at a detached commit.
     //
     // This is useful when running tasks on Travis, where the builds runs in
     // a detached commit. See the discussion here:
@@ -93,7 +93,7 @@ object PlayBuildBase extends AutoPlugin {
     } orElse {
       sys.props.get("currentBranch")
     } getOrElse {
-      "master"
+      "main"
     },
 
     pomExtra := {

--- a/src/sbt-test/interplay/library/build.sbt
+++ b/src/sbt-test/interplay/library/build.sbt
@@ -17,7 +17,7 @@ InputKey[Unit]("contains") := {
 TaskKey[Unit]("verifyOmnidocSourceUrl") := {
   import java.util.jar.JarFile
 
-  val expected = "https://github.com/playframework/mock/tree/master"
+  val expected = "https://github.com/playframework/mock/tree/main"
 
   val sourceUrl = omnidocSourceUrl.value
   sourceUrl match {


### PR DESCRIPTION
@SethTisue and @ihostage already renamed the `master` branch in some play repos:
* https://github.com/playframework/cachecontrol/pull/163
* https://github.com/playframework/play-file-watch/pull/136
* https://github.com/playframework/play-json/pull/598
* https://github.com/playframework/play-soap/pull/282
* https://github.com/playframework/play-ws/pull/597
* https://github.com/playframework/twirl/pull/416

Now that we are centralising configs in the [`.github`](https://github.com/playframework/.github) repo it's a good idea that all repos have the same default branch name.

To change to `main` locally (if the remote to this repo is called `upstream`):
```sh
git branch -m master main # rename master to main (actually "move")
git fetch upstream
git branch -u upstream/main main # set upstream
git remote set-head upstream -a # make sure HEAD is set correctly for this remote (autodetect)
```