### PR TITLE
Upgrade sbt-buildinfo

### DIFF
--- a/project/project/buildinfo.sbt
+++ b/project/project/buildinfo.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")


### PR DESCRIPTION
Seems like scala-steward does not upgrade this one.
Wait... Maybe that's because this wasn't published to maven central before.