### PR TITLE
Drop Java 8 / Scala upgrades

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -17,8 +17,8 @@ jobs:
     name: Tests
     uses: playframework/.github/.github/workflows/cmd.yml@v2
     with:
-      java: 11, 8
-      scala: 2.12.16
+      java: 17, 11
+      scala: 2.12.17
       env: |
         BUILD_REASON=IndividualCI
         PGP_SECRET=foo

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ addSbtPlugin("com.github.sbt" % "sbt-ci-release" % sbtCiReleaseVersion)
 libraryDependencies += "com.typesafe" % "config" % configVersion
 
 scalacOptions ++= Seq(
-  "-target:jvm-1.8",
+  "-release:11",
   "-Xlint",
   "-Ywarn-unused:imports",
   "-Xlint:nullary-unit",
@@ -29,8 +29,7 @@ scalacOptions ++= Seq(
 )
 
 javacOptions ++= Seq(
-  "-source", "1.8",
-  "-target", "1.8",
+  "--release", "11",
   "-Xlint:deprecation",
   "-Xlint:unchecked",
 )

--- a/src/main/scala/interplay/PlayLibraryBase.scala
+++ b/src/main/scala/interplay/PlayLibraryBase.scala
@@ -22,8 +22,8 @@ import interplay.Omnidoc.autoImport.omnidocTagPrefix
   override def projectSettings = Seq(
     omnidocGithubRepo := s"playframework/${(ThisBuild / playBuildRepoName).value}",
     omnidocTagPrefix := "",
-    compile / javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
-    doc / javacOptions := Seq("-source", "1.8"),
+    compile / javacOptions ++= Seq("--release", "11"),
+    doc / javacOptions := Seq("-source", "11"),
     crossScalaVersions := Seq(scalaVersion.value), // TODO: Add ScalaVersions.scala3
     scalaVersion := sys.props.get("scala.version").getOrElse(ScalaVersions.scala213),
   )

--- a/src/main/scala/interplay/PlaySbtBuildBase.scala
+++ b/src/main/scala/interplay/PlaySbtBuildBase.scala
@@ -12,7 +12,7 @@ private[interplay] object PlaySbtBuildBase extends AutoPlugin {
     scalaVersion := ScalaVersions.scala212,
     crossScalaVersions := Seq(ScalaVersions.scala212),
     pluginCrossBuild / sbtVersion := SbtVersions.sbt17,
-    compile / javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
-    doc / javacOptions := Seq("-source", "1.8")
+    compile / javacOptions ++= Seq("--release", "11"),
+    doc / javacOptions := Seq("-source", "11")
   )
 }

--- a/src/main/scala/interplay/Versions.scala
+++ b/src/main/scala/interplay/Versions.scala
@@ -1,9 +1,9 @@
 package interplay
 
 object ScalaVersions {
-  val scala212 = "2.12.16"
-  val scala213 = "2.13.8"
-  val scala3   = "3.1.3"
+  val scala212 = "2.12.17"
+  val scala213 = "2.13.9"
+  val scala3   = "3.2.0"
 }
 
 object SbtVersions {


### PR DESCRIPTION
I now we want retire interplay, however it's easier right now to just release new version with this values updates until interplay got removed everywhere.