### PR TITLE
[2.1.x] sbt pgp 2.0.1

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,7 @@ libraryDependencies ++= Seq(
 )
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.12")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.8.1")
 addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.18")
 


### PR DESCRIPTION
Wasn't able to release Play 2.8.19 because of a weird problem:
```
gpg: signing failed: Cannot allocate memory
```
That never occured to me before, seems like my M1 is way faster then my old laptop and now tries to sign too many artifacts in parellel. Also happened others before:
* https://github.com/sbt/sbt-pgp/issues/168
* Fortunatly the fix https://github.com/sbt/sbt-pgp/pull/171 made it into 2.0.1 (https://github.com/sbt/sbt-pgp/compare/v2.0.0...v2.0.1) so upgrading will make future Play 2.8.x not complain anymore. As a workaround I set `auto-expand-secmem` in my `gpg-agent.conf` for now.